### PR TITLE
Redesign Suitability Function workflow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ v0.1.0 (unreleased)
 -------------------
 Contributor to this version: Baptiste Hamon (@baptistehamon).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* Changes in ``SuitabilityFunction``:
+    * ``SuitabilityFunction`` is now an abstract class and must not be instantiated directly.
+    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
+    * ``SuitabilityFunction`` does not support the option to retrieve the implemented function from the ``func_method`` anymore.
+    * ``map`` has been deprecated because of its redundancy with the ``__call__`` method. Changes will be permanent in LSAPy v0.1.0. Call the function directly instead.
+
 Internal changes
 ^^^^^^^^^^^^^^^^
 * Templates for requesting new features, asking question and submitting PR have been added (issue `#11 <https://github.com/baptistehamon/lsapy/issues/11>`_, PR `#12 <https://github.com/baptistehamon/lsapy/pull/12>`_).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,8 +11,11 @@ Breaking changes
 * Changes in ``SuitabilityFunction``:
     * ``SuitabilityFunction`` is now an abstract class and must not be instantiated directly.
     * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
-    * ``SuitabilityFunction`` does not support the option to retrieve the implemented function from the ``func_method`` anymore.
+    * ``SuitabilityFunction`` does not support the option to retrieve the implemented function from the ``func_method`` anymore. This is now implemented in the ``MembershipFunction`` class.
     * ``map`` has been deprecated because of its redundancy with the ``__call__`` method. Changes will be permanent in LSAPy v0.1.0. Call the function directly instead.
+* ``MembershipSuitFunction`` has been renamed to ``MembershipFunction``:
+    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
+    * ``fit`` method has been renamed to ``fit_functions``.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,9 @@ Internal changes
 * `Pre-commit` has been setup and `ruff`, `codespell` and `numpydoc` hooks have been added (issue `#8 <https://github.com/baptistehamon/lsapy/issues/8>`_, PR `#18 <https://github.com/baptistehamon/lsapy/pull/18>`_/PR `#19 <https://github.com/baptistehamon/lsapy/pull/19>`_).
 * The autoupdate schedule of `pre-commit` has been set to weekly (PR `#21 <https://github.com/baptistehamon/lsapy/pull/21>`_)
 * The unused ``introduction.ipynb`` notebook has been removed (issue `#15 <https://github.com/baptistehamon/lsapy/issues/15>`_, PR `#20 <https://github.com/baptistehamon/lsapy/pull/20>`_).
+* The structure around ``SuitabilityFunction``, ``MembershipFunction``, and ``DiscreteFunction`` has been redesigned :
+    * The ``SuitabilityFunction`` has been moved to LSAPy ``core`` module.
+    * The ``MembershipFunction`` and ``DiscreteFunction`` have been moved to the ``function`` module and split into two different files: ``membership.py`` and ``discrete.py``.
 
 v0.1.0-dev2 (2025-05-25)
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ Breaking changes
 * ``MembershipSuitFunction`` has been renamed to ``MembershipFunction``:
     * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
     * ``fit`` method has been renamed to ``fit_functions``.
+* ``DiscreteSuitFunction`` has been renamed to ``DiscreteFunction``:
+    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
 
 Internal changes
 ^^^^^^^^^^^^^^^^

--- a/src/lsapy/core/__init__.py
+++ b/src/lsapy/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core Module."""

--- a/src/lsapy/core/functions.py
+++ b/src/lsapy/core/functions.py
@@ -1,0 +1,141 @@
+"""Suitability Function Utilities."""
+
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from attr import asdict, define, field
+
+__all__ = ["SuitabilityFunction"]
+
+
+@define
+class SuitabilityFunction:
+    """
+    Suitability Function base class.
+
+    Suitability function define how the criteria indicator is transformed into a suitability value. The suitability
+    function are available for continuous and discrete indicators. For continuous indicators, a membership function
+    is used to transform the indicator into a suitability value. For discrete indicators, a set of rules is mapped
+    on the indicator.
+
+    Parameters
+    ----------
+    func : Callable | None, optional
+        Function to compute the suitability value.
+    name : str | None, optional
+        Name of the function to compute the suitability value. By default, the name of the function is used if provided,
+        otherwise it is set to `None`.
+    params : dict[str, Any], optional
+        Parameters of the function.
+
+    See Also
+    --------
+    MembershipFunction : Membership Suitability Function.
+    DiscreteFunction : Discrete Suitability Function.
+
+    Examples
+    --------
+    >>> from lsapy.functions import logistic
+    >>> sf = SuitabilityFunction(func=logistic, params={"a": 1, "b": 5})
+
+    ``SuitabilityFunction`` can also be used for discrete functions.
+
+    >>> from lsapy.functions import discrete
+    >>> sf = SuitabilityFunction(func=discrete, params={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
+    """
+
+    func: Callable | None = field(repr=lambda f: f.__name__ if f else None)
+    name: str | None
+    params: dict[str, Any] | None
+
+    def __init__(self, func: Callable | None = None, name: str | None = None, params: dict[str, Any] = None):
+        if func is not None and not callable(func):
+            raise TypeError("`func` must be a callable function.")
+        self.func = func
+
+        if name:
+            self.name = name
+        elif func is not None:
+            self.name = func.__name__
+        else:
+            self.name = None
+
+        self.params = params
+
+    def __call__(self, x):
+        """Call the suitability function."""
+        if self.func is None:
+            raise ValueError("No function has been provided.")
+        return np.vectorize(self.func, otypes=[np.float32])(x, **self.params)
+
+    def map(self, x):
+        """
+        Map the suitability function.
+
+        This method converts the input values into suitability values for the defined function.
+
+        Parameters
+        ----------
+        x : any
+            Input values to map.
+
+        Returns
+        -------
+        any
+            Suitability values.
+
+        Raises
+        ------
+        ValueError
+            If no function has been provided.
+
+        Examples
+        --------
+        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
+        >>> sf.map(3)
+        array(0.11920292, dtype=float32)
+
+        .. deprecated:: 0.1.0-dev2
+          `map` will be removed in LSAPy 0.1.0 because it is redundant with the `__call__` method.
+          Please use the `__call__` method directly instead.
+        """
+        warnings.warn(
+            "`map` is deprecated and will be removed in LSAPy 0.1.0. Use `__call__` directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self(x)
+
+    def plot(self, x) -> None:
+        """
+        Basic plot of the suitability function.
+
+        Parameters
+        ----------
+        x : any
+            Input values to plot.
+
+        Examples
+        --------
+        >>> import numpy as np  # doctest: +SKIP
+        <BLANKLINE>
+        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
+        >>> sf.plot(np.linspace(0, 10, 100))  # doctest: +SKIP
+        """
+        plt.plot(x, self(x))
+
+    @property
+    def attrs(self):
+        """
+        Dictionary of the suitability function attributes.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the function name and parameters. If both are undefined, an empty dictionary
+            is returned.
+        """
+        return {k: v for k, v in asdict(self).items() if v is not None and k not in ["func"]}

--- a/src/lsapy/criteria.py
+++ b/src/lsapy/criteria.py
@@ -2,7 +2,7 @@
 
 import xarray as xr
 
-from lsapy.functions import DiscreteSuitFunction, MembershipSuitFunction, SuitabilityFunction
+from lsapy.functions import DiscreteSuitFunction, MembershipFunction, SuitabilityFunction
 
 __all__ = ["SuitabilityCriteria"]
 
@@ -21,7 +21,7 @@ class SuitabilityCriteria:
         Name of the suitability criteria.
     indicator : xr.DataArray
         Indicator on which the criteria is based.
-    func : SuitabilityFunction | MembershipSuitFunction | DiscreteSuitFunction
+    func : SuitabilityFunction | MembershipFunction | DiscreteSuitFunction
         Suitability function describing how the suitability of the criteria is computed.
     weight : int | float | None, optional
         Weight of the criteria used in the aggregation process if a weighted aggregation method is used.
@@ -69,7 +69,7 @@ class SuitabilityCriteria:
         self,
         name: str,
         indicator: xr.Dataset | xr.DataArray,  # TODO: check if it's work with ds
-        func: SuitabilityFunction | MembershipSuitFunction | DiscreteSuitFunction,
+        func: SuitabilityFunction | MembershipFunction | DiscreteSuitFunction,
         weight: int | float | None = 1,
         category: str | None = None,
         long_name: str | None = None,

--- a/src/lsapy/criteria.py
+++ b/src/lsapy/criteria.py
@@ -2,7 +2,7 @@
 
 import xarray as xr
 
-from lsapy.functions import DiscreteSuitFunction, MembershipFunction, SuitabilityFunction
+from lsapy.functions import DiscreteFunction, MembershipFunction
 
 __all__ = ["SuitabilityCriteria"]
 
@@ -69,7 +69,7 @@ class SuitabilityCriteria:
         self,
         name: str,
         indicator: xr.Dataset | xr.DataArray,  # TODO: check if it's work with ds
-        func: SuitabilityFunction | MembershipFunction | DiscreteSuitFunction,
+        func: MembershipFunction | DiscreteFunction,
         weight: int | float | None = 1,
         category: str | None = None,
         long_name: str | None = None,

--- a/src/lsapy/functions.py
+++ b/src/lsapy/functions.py
@@ -9,7 +9,7 @@ import numpy as np
 from attrs import asdict, define, field
 from scipy.optimize import curve_fit
 
-__all__ = ["MembershipFunction", "DiscreteSuitFunction"]
+__all__ = ["MembershipFunction", "DiscreteFunction"]
 
 
 @define
@@ -35,7 +35,7 @@ class SuitabilityFunction:
     See Also
     --------
     MembershipFunction : Membership Suitability Function.
-    DiscreteSuitFunction : Discrete Suitability Function.
+    DiscreteFunction : Discrete Suitability Function.
 
     Examples
     --------
@@ -160,7 +160,7 @@ class MembershipFunction(SuitabilityFunction):
 
     See Also
     --------
-    DiscreteSuitFunction : Discrete Suitability Function.
+    DiscreteFunction : Discrete Suitability Function.
 
     Examples
     --------
@@ -317,7 +317,7 @@ def _fit_membership_func(x, y, methods: str | list[str] = "all", plot: bool = Fa
     return _get_function_from_name(f_best), p_best
 
 
-class DiscreteSuitFunction(SuitabilityFunction):
+class DiscreteFunction(SuitabilityFunction):
     """
     Discrete Suitability Function.
 
@@ -326,28 +326,25 @@ class DiscreteSuitFunction(SuitabilityFunction):
 
     Parameters
     ----------
-    func_params : dict[str, int | float] | None, optional
-        Parameters of the function. The keys correspond to the indicator values and the values to its associated
-        suitability values.
+    rules : dict[str, int | float] | None, optional
+        Rules to map the indicator values to suitability values. The keys correspond to the indicator values and the
+        values to its associated suitability values.
 
     See Also
     --------
-    SuitabilityFunction : Suitability Function.
     MembershipFunction : Membership Suitability Function.
 
     Examples
     --------
-    >>> func = DiscreteSuitFunction(func_params={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
+    >>> func = DiscreteFunction(rules={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
 
-    ``DiscreteSuitFunction`` also support keys as strings.
+    ``DiscreteFunction`` also support keys as strings.
 
-    >>> func = DiscreteSuitFunction(func_params={"1": 0, "2": 0.1, "3": 0.5, "4": 0.9, "5": 1})
+    >>> func = DiscreteFunction(rules={"1": 0, "2": 0.1, "3": 0.5, "4": 0.9, "5": 1})
     """
 
-    def __init__(self, func_params: dict[str, int | float] | None = None):
-        self.func = discrete
-        self.func_method = "discrete"
-        self.func_params = func_params
+    def __init__(self, rules: dict[str | int, int | float] | None = None):
+        super().__init__(func=discrete, name="discrete", params={"rules": rules})
 
 
 equations: dict[str, dict] = {}

--- a/src/lsapy/functions.py
+++ b/src/lsapy/functions.py
@@ -9,7 +9,7 @@ import numpy as np
 from attrs import asdict, define, field
 from scipy.optimize import curve_fit
 
-__all__ = ["MembershipSuitFunction", "DiscreteSuitFunction"]
+__all__ = ["MembershipFunction", "DiscreteSuitFunction"]
 
 
 @define
@@ -34,7 +34,7 @@ class SuitabilityFunction:
 
     See Also
     --------
-    MembershipSuitFunction : Membership Suitability Function.
+    MembershipFunction : Membership Suitability Function.
     DiscreteSuitFunction : Discrete Suitability Function.
 
     Examples
@@ -141,7 +141,7 @@ class SuitabilityFunction:
         return {k: v for k, v in asdict(self).items() if v is not None and k not in ["func"]}
 
 
-class MembershipSuitFunction(SuitabilityFunction):
+class MembershipFunction(SuitabilityFunction):
     """
     Membership Suitability Function.
 
@@ -152,38 +152,42 @@ class MembershipSuitFunction(SuitabilityFunction):
     ----------
     func : Callable | None, optional
         Function to compute the suitability value.
-    func_method : str | None, optional
-        Name of the function to compute the suitability value. If `func` is not provided and `func_method` is provided,
-        the function will be retrieved from the available implemented equations.
-    func_params : dict[str, int | float] | None, optional
-        Parameters of the function to compute the suitability value.
+    name : str | None, optional
+        Name of the function to compute the suitability value. By default, the name of the function is used if provided,
+        otherwise it is set to `None`.
+    params : dict[str, int | float] | None, optional
+        Parameters of the function.
 
     See Also
     --------
-    SuitabilityFunction : Suitability Function.
     DiscreteSuitFunction : Discrete Suitability Function.
 
     Examples
     --------
-    >>> func = MembershipSuitFunction(func_method="logistic", func_params={"a": 1, "b": 5})
-    >>> func(3)
-    np.float64(0.11920292202211755)
+    >>> mf = MembershipFunction(name="logistic", params={"a": 1, "b": 5})
+    >>> mf(3)
+    array(0.11920292, dtype=float32)
     """
 
     def __init__(
         self,
         func: Callable | None = None,
-        func_method: str | None = None,
-        func_params: dict[str, int | float] | None = None,
+        name: str | None = None,
+        params: dict[str, int | float] | None = None,
     ):
-        super().__init__(func, func_method, func_params)
+        super().__init__(func, name, params)
+        if func is None and name is not None:
+            try:
+                self.func = _get_function_from_name(name)
+            except Exception:
+                warnings.warn("`name` not found in implemented equations. Setting `func` to None.", stacklevel=2)
 
     @staticmethod
-    def fit(x, y=None, methods: str | list[str] = "all", plot: bool = False):
+    def fit_functions(x, y=None, methods: str | list[str] = "all", plot: bool = False):
         """
         Fit the membership functions to data.
 
-        This methods help to identify the best membership function to use on the data by fitting
+        This method help to identify the best membership function to use on the data by fitting
         the available functions.
         # TODO: check if results should be print or return
 
@@ -207,7 +211,7 @@ class MembershipSuitFunction(SuitabilityFunction):
 
         Examples
         --------
-        >>> MembershipSuitFunction.fit([1, 3, 5, 7, 10])  # doctest: +SKIP
+        >>> MembershipFunction.fit_functions([1, 3, 5, 7, 10])  # doctest: +SKIP
         Skipped fitting for the following methods: sigmoid, vetharaniam2024_eq8.
         <BLANKLINE>
         Best fit: logistic
@@ -219,7 +223,7 @@ class MembershipSuitFunction(SuitabilityFunction):
         By default, the function will fit all available methods. If you want to fit only specific methods, you can
         specify the methods to fit: "all", "sigmoid_like", "gaussian_like", or a list of methods.
 
-        >>> MembershipSuitFunction.fit(
+        >>> MembershipFunction.fit_functions(
         ...     x=[1, 3, 5, 5, 7, 9], y=[0, 0.5, 1, 1, 0.5, 0], methods="gaussian_like"
         ... )  # doctest: +SKIP
         Skipped fitting for the following methods: vetharaniam2024_eq8.
@@ -232,7 +236,7 @@ class MembershipSuitFunction(SuitabilityFunction):
         """
         if y is None:
             y = [0, 0.25, 0.5, 0.75, 1]
-        return _fit_mbs_functions(x, np.array(y), methods, plot)
+        return _fit_membership_func(x, np.array(y), methods, plot)
 
 
 def _prepare_for_fitting(methods: str | list[str] = "all"):
@@ -276,7 +280,7 @@ def _get_function_p0(method: str, x: np.ndarray) -> list[float]:
     return []
 
 
-def _fit_mbs_functions(x, y, methods: str | list[str] = "all", plot: bool = False):
+def _fit_membership_func(x, y, methods: str | list[str] = "all", plot: bool = False):
     skipped = []
     methods, _skipped = _prepare_for_fitting(methods)
     skipped.extend(_skipped)
@@ -329,7 +333,7 @@ class DiscreteSuitFunction(SuitabilityFunction):
     See Also
     --------
     SuitabilityFunction : Suitability Function.
-    MembershipSuitFunction : Membership Suitability Function.
+    MembershipFunction : Membership Suitability Function.
 
     Examples
     --------

--- a/src/lsapy/functions.py
+++ b/src/lsapy/functions.py
@@ -6,14 +6,16 @@ from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
+from attrs import asdict, define, field
 from scipy.optimize import curve_fit
 
-__all__ = ["SuitabilityFunction", "MembershipSuitFunction", "DiscreteSuitFunction"]
+__all__ = ["MembershipSuitFunction", "DiscreteSuitFunction"]
 
 
+@define
 class SuitabilityFunction:
     """
-    Base class for suitability functions.
+    Suitability Function base class.
 
     Suitability function define how the criteria indicator is transformed into a suitability value. The suitability
     function are available for continuous and discrete indicators. For continuous indicators, a membership function
@@ -24,12 +26,11 @@ class SuitabilityFunction:
     ----------
     func : Callable | None, optional
         Function to compute the suitability value.
-    func_method : str | None, optional
-        Name of the function to compute the suitability value. If `func` is not provided and `func_method` is provided,
-        the function will be retrieved from the available implemented equations.
-    func_params : dict[str, Any], optional
-        Parameters of the function. For discrete functions, the keys correspond to the indicator values and
-        the values to its associated suitability values.
+    name : str | None, optional
+        Name of the function to compute the suitability value. By default, the name of the function is used if provided,
+        otherwise it is set to `None`.
+    params : dict[str, Any], optional
+        Parameters of the function.
 
     See Also
     --------
@@ -38,59 +39,37 @@ class SuitabilityFunction:
 
     Examples
     --------
-    >>> func = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
+    >>> from lsapy.functions import logistic
+    >>> sf = SuitabilityFunction(func=logistic, params={"a": 1, "b": 5})
 
     ``SuitabilityFunction`` can also be used for discrete functions.
 
-    >>> func = SuitabilityFunction(func_method="discrete", func_params={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
+    >>> from lsapy.functions import discrete
+    >>> sf = SuitabilityFunction(func=discrete, params={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
     """
 
-    def __init__(
-        self, func: Callable | None = None, func_method: str | None = None, func_params: dict[str, Any] = None
-    ):
-        if func_params is not None:
-            if func is None and func_method is None:
-                raise ValueError("If `func_params` is provided, `func` or `func_method` must also be provided.")
-        else:
-            func_params = {}
+    func: Callable | None = field(repr=lambda f: f.__name__ if f else None)
+    name: str | None
+    params: dict[str, Any] | None
 
+    def __init__(self, func: Callable | None = None, name: str | None = None, params: dict[str, Any] = None):
+        if func is not None and not callable(func):
+            raise TypeError("`func` must be a callable function.")
         self.func = func
-        self.func_method = func_method
-        self.func_params = func_params
-        if func is None and func_method is not None:
-            self.func = _get_function_from_name(func_method)
 
-    def __repr__(self):
-        """Return the string representation of the object."""
-        return (
-            f"{self.__class__.__name__}("
-            f"func={self.func.__name__}, "
-            f"func_method='{self.func_method}', "
-            f"func_params={self.func_params})"
-        )
+        if name:
+            self.name = name
+        elif func is not None:
+            self.name = func.__name__
+        else:
+            self.name = None
+
+        self.params = params
 
     def __call__(self, x):
-        """
-        Compute the suitability value.
-
-        Parameters
-        ----------
-        x : any
-            Input values.
-
-        Returns
-        -------
-        any
-            Suitability values.
-
-        Raises
-        ------
-        ValueError
-            If no function has been provided.
-        """
         if self.func is None:
             raise ValueError("No function has been provided.")
-        return self.func(x, **self.func_params)  # TODO: implement vectorization to support list
+        return np.vectorize(self.func, otypes=[np.float32])(x, **self.params)
 
     def map(self, x):
         """
@@ -115,10 +94,19 @@ class SuitabilityFunction:
 
         Examples
         --------
-        >>> func = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
-        >>> func.map(3)
-        np.float64(0.11920292202211755)
+        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
+        >>> sf.map(3)
+        array(0.11920292, dtype=float32)
+
+        .. deprecated:: 0.1.0-dev2
+          `map` will be removed in LSAPy 0.1.0 because it is redundant with the `__call__` method.
+          Please use the `__call__` method directly instead.
         """
+        warnings.warn(
+            "`map` is deprecated and will be removed in LSAPy 0.1.0. Use `__call__` directly instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self(x)
 
     def plot(self, x) -> None:
@@ -134,8 +122,8 @@ class SuitabilityFunction:
         --------
         >>> import numpy as np  # doctest: +SKIP
         <BLANKLINE>
-        >>> func = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
-        >>> func.plot(np.linspace(0, 10, 100))  # doctest: +SKIP
+        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
+        >>> sf.plot(np.linspace(0, 10, 100))  # doctest: +SKIP
         """
         plt.plot(x, self(x))
 
@@ -147,14 +135,10 @@ class SuitabilityFunction:
         Returns
         -------
         dict
-            Dictionary containing the function method and parameters. If both are undefined, an empty dictionary
+            Dictionary containing the function name and parameters. If both are undefined, an empty dictionary
             is returned.
         """
-        if self.func_method is None and self.func_params is None:
-            return {}
-        return {
-            k: v for k, v in {"func_method": self.func_method, "func_params": self.func_params}.items() if v is not None
-        }
+        return {k: v for k, v in asdict(self).items() if v is not None and k not in ["func"]}
 
 
 class MembershipSuitFunction(SuitabilityFunction):

--- a/src/lsapy/functions/__init__.py
+++ b/src/lsapy/functions/__init__.py
@@ -1,0 +1,4 @@
+"""Suitability Functions Module."""
+
+from lsapy.functions.discrete import *
+from lsapy.functions.membership import *

--- a/src/lsapy/functions/discrete.py
+++ b/src/lsapy/functions/discrete.py
@@ -1,0 +1,62 @@
+"""Discrete Suitability Function definition."""
+
+import numpy as np
+
+from lsapy.core.functions import SuitabilityFunction
+
+__all__ = [
+    "DiscreteFunction",
+    "discrete",
+]
+
+
+class DiscreteFunction(SuitabilityFunction):
+    """
+    Discrete Suitability Function.
+
+    Discrete functions are used to transform discrete indicator values into suitability values. The discrete functions
+    map the indicator values to a set of rules that define the suitability values.
+
+    Parameters
+    ----------
+    rules : dict[str, int | float] | None, optional
+        Rules to map the indicator values to suitability values. The keys correspond to the indicator values and the
+        values to its associated suitability values.
+
+    See Also
+    --------
+    MembershipFunction : Membership Suitability Function.
+
+    Examples
+    --------
+    >>> func = DiscreteFunction(rules={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
+
+    ``DiscreteFunction`` also support keys as strings.
+
+    >>> func = DiscreteFunction(rules={"1": 0, "2": 0.1, "3": 0.5, "4": 0.9, "5": 1})
+    """
+
+    def __init__(self, rules: dict[str | int, int | float] | None = None):
+        super().__init__(func=discrete, name="discrete", params={"rules": rules})
+
+
+def discrete(x, rules: dict[str | int, int | float]) -> float:
+    """
+    Discrete suitability function.
+
+    This function maps the indicator values to a set of rules that define the suitability values.
+
+    Parameters
+    ----------
+    x : any
+        Indicator values to map.
+    rules : dict[str | int, int | float]
+        Rules to map the indicator values to suitability values. The keys correspond to the indicator values and the
+        values to its associated suitability values.
+
+    Returns
+    -------
+    float
+        Suitability values.
+    """
+    return np.vectorize(rules.get, otypes=[np.float32])(x, np.nan)

--- a/src/lsapy/functions/membership.py
+++ b/src/lsapy/functions/membership.py
@@ -1,144 +1,23 @@
-"""Suitability Functions definitions."""
+"""Membership Suitability Function definition."""
 
 import warnings
 from collections.abc import Callable
-from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
-from attrs import asdict, define, field
 from scipy.optimize import curve_fit
 
-__all__ = ["MembershipFunction", "DiscreteFunction"]
+from lsapy.core.functions import SuitabilityFunction
 
-
-@define
-class SuitabilityFunction:
-    """
-    Suitability Function base class.
-
-    Suitability function define how the criteria indicator is transformed into a suitability value. The suitability
-    function are available for continuous and discrete indicators. For continuous indicators, a membership function
-    is used to transform the indicator into a suitability value. For discrete indicators, a set of rules is mapped
-    on the indicator.
-
-    Parameters
-    ----------
-    func : Callable | None, optional
-        Function to compute the suitability value.
-    name : str | None, optional
-        Name of the function to compute the suitability value. By default, the name of the function is used if provided,
-        otherwise it is set to `None`.
-    params : dict[str, Any], optional
-        Parameters of the function.
-
-    See Also
-    --------
-    MembershipFunction : Membership Suitability Function.
-    DiscreteFunction : Discrete Suitability Function.
-
-    Examples
-    --------
-    >>> from lsapy.functions import logistic
-    >>> sf = SuitabilityFunction(func=logistic, params={"a": 1, "b": 5})
-
-    ``SuitabilityFunction`` can also be used for discrete functions.
-
-    >>> from lsapy.functions import discrete
-    >>> sf = SuitabilityFunction(func=discrete, params={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
-    """
-
-    func: Callable | None = field(repr=lambda f: f.__name__ if f else None)
-    name: str | None
-    params: dict[str, Any] | None
-
-    def __init__(self, func: Callable | None = None, name: str | None = None, params: dict[str, Any] = None):
-        if func is not None and not callable(func):
-            raise TypeError("`func` must be a callable function.")
-        self.func = func
-
-        if name:
-            self.name = name
-        elif func is not None:
-            self.name = func.__name__
-        else:
-            self.name = None
-
-        self.params = params
-
-    def __call__(self, x):
-        if self.func is None:
-            raise ValueError("No function has been provided.")
-        return np.vectorize(self.func, otypes=[np.float32])(x, **self.params)
-
-    def map(self, x):
-        """
-        Map the suitability function.
-
-        This method converts the input values into suitability values for the defined function.
-
-        Parameters
-        ----------
-        x : any
-            Input values to map.
-
-        Returns
-        -------
-        any
-            Suitability values.
-
-        Raises
-        ------
-        ValueError
-            If no function has been provided.
-
-        Examples
-        --------
-        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
-        >>> sf.map(3)
-        array(0.11920292, dtype=float32)
-
-        .. deprecated:: 0.1.0-dev2
-          `map` will be removed in LSAPy 0.1.0 because it is redundant with the `__call__` method.
-          Please use the `__call__` method directly instead.
-        """
-        warnings.warn(
-            "`map` is deprecated and will be removed in LSAPy 0.1.0. Use `__call__` directly instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self(x)
-
-    def plot(self, x) -> None:
-        """
-        Basic plot of the suitability function.
-
-        Parameters
-        ----------
-        x : any
-            Input values to plot.
-
-        Examples
-        --------
-        >>> import numpy as np  # doctest: +SKIP
-        <BLANKLINE>
-        >>> sf = SuitabilityFunction(func_method="logistic", func_params={"a": 1, "b": 5})
-        >>> sf.plot(np.linspace(0, 10, 100))  # doctest: +SKIP
-        """
-        plt.plot(x, self(x))
-
-    @property
-    def attrs(self):
-        """
-        Dictionary of the suitability function attributes.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the function name and parameters. If both are undefined, an empty dictionary
-            is returned.
-        """
-        return {k: v for k, v in asdict(self).items() if v is not None and k not in ["func"]}
+__all__ = [
+    "MembershipFunction",
+    "logistic",
+    "sigmoid",
+    "vetharaniam2022_eq3",
+    "vetharaniam2022_eq5",
+    "vetharaniam2024_eq8",
+    "vetharaniam2024_eq10",
+]
 
 
 class MembershipFunction(SuitabilityFunction):
@@ -317,36 +196,6 @@ def _fit_membership_func(x, y, methods: str | list[str] = "all", plot: bool = Fa
     return _get_function_from_name(f_best), p_best
 
 
-class DiscreteFunction(SuitabilityFunction):
-    """
-    Discrete Suitability Function.
-
-    Discrete functions are used to transform discrete indicator values into suitability values. The discrete functions
-    map the indicator values to a set of rules that define the suitability values.
-
-    Parameters
-    ----------
-    rules : dict[str, int | float] | None, optional
-        Rules to map the indicator values to suitability values. The keys correspond to the indicator values and the
-        values to its associated suitability values.
-
-    See Also
-    --------
-    MembershipFunction : Membership Suitability Function.
-
-    Examples
-    --------
-    >>> func = DiscreteFunction(rules={1: 0, 2: 0.1, 3: 0.5, 4: 0.9, 5: 1})
-
-    ``DiscreteFunction`` also support keys as strings.
-
-    >>> func = DiscreteFunction(rules={"1": 0, "2": 0.1, "3": 0.5, "4": 0.9, "5": 1})
-    """
-
-    def __init__(self, rules: dict[str | int, int | float] | None = None):
-        super().__init__(func=discrete, name="discrete", params={"rules": rules})
-
-
 equations: dict[str, dict] = {}
 
 
@@ -380,29 +229,6 @@ def equation(type: str):
         return func
 
     return _decorator
-
-
-@equation("discrete")
-def discrete(x, rules: dict[str | int, int | float]) -> float:
-    """
-    Discrete suitability function.
-
-    This function maps the indicator values to a set of rules that define the suitability values.
-
-    Parameters
-    ----------
-    x : any
-        Indicator values to map.
-    rules : dict[str | int, int | float]
-        Rules to map the indicator values to suitability values. The keys correspond to the indicator values and the
-        values to its associated suitability values.
-
-    Returns
-    -------
-    float
-        Suitability values.
-    """
-    return np.vectorize(rules.get, otypes=[np.float32])(x, np.nan)
 
 
 @equation("sigmoid")


### PR DESCRIPTION
<!--This template come from [xclim](https://github.com/Ouranosinc/xclim) project.-->
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (issue #N) and pull request (PR #N) has been added

### What kind of change does this PR introduce?

* The structure around ``SuitabilityFunction``, ``MembershipFunction``, and ``DiscreteFunction`` has been redesigned :
    * The ``SuitabilityFunction`` has been moved to LSAPy ``core`` module.
    * The ``MembershipFunction`` and ``DiscreteFunction`` have been moved to the ``function`` module and split into two different files: ``membership.py`` and ``discrete.py``.

### Does this PR introduce a breaking change?

* Changes in ``SuitabilityFunction``:
    * ``SuitabilityFunction`` is now an abstract class and must not be instantiated directly.
    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
    * ``SuitabilityFunction`` does not support the option to retrieve the implemented function from the ``func_method`` anymore. This is now implemented in the ``MembershipFunction`` class.
    * ``map`` has been deprecated because of its redundancy with the ``__call__`` method. Changes will be permanent in LSAPy v0.1.0. Call the function directly instead.
* ``MembershipSuitFunction`` has been renamed to ``MembershipFunction``:
    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.
    * ``fit`` method has been renamed to ``fit_functions``.
* ``DiscreteSuitFunction`` has been renamed to ``DiscreteFunction``:
    * ``func_method`` and ``func_params`` have been renamed to ``name`` and ``params`` respectively.

### Other information:
