### PR TITLE
Remove deprecated SuitabilityFunction.map

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ New features
 * Functions alternative names can now be used in ``SuitabilityFunction`` (PR `#43 <https://github.com/baptistehamon/lsapy/pull/43>`_).
 * The documentation of membership functions has been improved (PR `#43 <https://github.com/baptistehamon/lsapy/pull/43>`_).
 
+Breaking changes
+^^^^^^^^^^^^^^^^
+* The deprecated ``SuitabilityFunction.map`` method has been removed (PR `#44 <https://github.com/baptistehamon/lsapy/pull/44>`_).
+
 v0.1.1 (2025-07-26)
 -------------------
 Contributor to this version: Baptiste Hamon (@baptistehamon).

--- a/src/lsapy/functions/_suitability.py
+++ b/src/lsapy/functions/_suitability.py
@@ -105,46 +105,6 @@ class SuitabilityFunction:
         """
         return {k: v for k, v in {"func": self.func, "params": self.params}.items() if v is not None}
 
-    def map(self, x):
-        """
-        Map the suitability function.
-
-        This method converts the input values into suitability values for the defined function.
-
-        Parameters
-        ----------
-        x : any
-            Input values to map.
-
-        Returns
-        -------
-        any
-            Suitability values.
-
-        Raises
-        ------
-        ValueError
-            If no function has been provided.
-
-        Examples
-        --------
-        >>> from lsapy.functions import logistic
-
-        >>> sf = SuitabilityFunction(func=logistic, params={"a": 1, "b": 5})
-        >>> sf.map(3)
-        array(0.11920292, dtype=float32)
-
-        .. deprecated:: 0.1.0-dev2
-          `map` will be removed in LSAPy 0.1.0 because it is redundant with the `__call__` method.
-          Please use the `__call__` method directly instead.
-        """
-        warnings.warn(
-            "`map` is deprecated and will be removed in LSAPy 0.1.0. Use `__call__` directly instead.",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self(x)
-
     def plot(self, x) -> None:
         """
         Basic plot of the suitability function.


### PR DESCRIPTION
<!--This template come from [xclim](https://github.com/Ouranosinc/xclim) project.-->
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [x] CHANGELOG.rst has been updated (with summary of main changes)
  - [x] Link to issue (issue #N) and pull request (PR #N) has been added

### What kind of change does this PR introduce?

* Remove the deprecated method `SuitabilityFunction.map`

### Does this PR introduce a breaking change?
Yes, remove `SuitabilityFunction.map`.
