### PR TITLE
Improve __repr__ methods of LSAPy classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     rev: v1.9.0
     hooks:
       - id: numpydoc-validation
-        exclude: ^docs/|^tests/|noxfile\.py
+        exclude: ^docs/|^tests/|noxfile.py|^src/lsapy/core/formatting.py
   - repo: https://github.com/jendrikseipp/vulture
     rev: 'v2.14'
     hooks:

--- a/src/lsapy/core/formatting.py
+++ b/src/lsapy/core/formatting.py
@@ -2,6 +2,18 @@
 
 from __future__ import annotations
 
+from xarray.core.formatting import (
+    _calculate_col_width,  # noqa: PLC2701
+    attrs_repr,
+    dim_summary_limited,
+    inline_variable_array_repr,
+    maybe_truncate,
+    pretty_print,
+    render_human_readable_nbytes,
+)
+
+from lsapy.core.options import OPTIONS
+
 
 def sf_repr(sf):
     """Return a string representation of a SuitabilityFunction."""
@@ -11,3 +23,61 @@ def sf_repr(sf):
 def sf_short_repr(sf):
     """Return a short string representation of a SuitabilityFunction."""
     return f"{sf.func.__name__}({', '.join(f'{k}={v}' for k, v in sf.params.items())})"
+
+
+def sc_params_repr(sc):
+    """Format "weight" and "category" for SuitabilityCriteria."""
+    summary = [f"weight: {sc.weight}"]
+    if sc.category:
+        summary.append(f"category: {sc.category}")
+    return f"({', '.join(summary)})"
+
+
+def data_repr(obj, col_width, max_width) -> str:
+    """Format indicator data for SuitabilityCriteria."""
+    first_col = pretty_print("    Data", col_width)
+    nbytes_str = f" {render_human_readable_nbytes(obj.nbytes)}"
+    front_str = f"{first_col}{obj.dtype}{nbytes_str} "
+
+    values_width = max_width - len(front_str)
+    values_str = inline_variable_array_repr(obj.variable, values_width)
+
+    return front_str + values_str
+
+
+def sc_repr(sc) -> str:
+    """Return a string representation of a SuitabilityCriteria."""
+    max_rows = OPTIONS["display_max_rows"]
+    max_width = OPTIONS["display_width"]
+
+    exclude_attrs = ["name", "weight", "category", "from_indicator", "is_computed"]
+    attrs = {k: v for k, v in sc.attrs.items() if k not in exclude_attrs}
+
+    col_width = _calculate_col_width([f"{k}:" for k in attrs.keys()] + ["Dimensions"])
+    name_col = pretty_print("    Name", col_width)
+
+    summary = [f"<SuitabilityCriteria> {sc.name!r}{sc_params_repr(sc)}"]
+
+    if sc.func:
+        summary.extend(
+            [
+                "Function:",
+                f"    {maybe_truncate(sf_short_repr(sc.func), max_width)}",
+                # f"{name_col}{sc.func.func.__name__} "
+                # f"{pretty_print("    Parameters", col_width)}{sc.func.params!r} "
+            ]
+        )
+
+    dims = pretty_print("    Dimensions", col_width)
+    summary.extend(
+        [
+            "Indicator:",
+            f"{name_col}{sc.indicator.name} ",
+            data_repr(sc.indicator, col_width, max_width),
+            f"{dims}{dim_summary_limited(sc.indicator.sizes, len(dims) + 1, max_rows)} ",
+        ]
+    )
+
+    summary.append(attrs_repr(attrs, max_rows=max_rows))
+
+    return "\n".join(summary)

--- a/src/lsapy/core/formatting.py
+++ b/src/lsapy/core/formatting.py
@@ -1,0 +1,13 @@
+"""String formatting routines for __repr__."""
+
+from __future__ import annotations
+
+
+def sf_repr(sf):
+    """Return a string representation of a SuitabilityFunction."""
+    return f"SuitabilityFunction(func={sf.func.__name__}, params={sf.params})"
+
+
+def sf_short_repr(sf):
+    """Return a short string representation of a SuitabilityFunction."""
+    return f"{sf.func.__name__}({', '.join(f'{k}={v}' for k, v in sf.params.items())})"

--- a/src/lsapy/core/formatting.py
+++ b/src/lsapy/core/formatting.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import functools
+
 from xarray.core.formatting import (
     _calculate_col_width,  # noqa: PLC2701
+    _mapping_repr,  # noqa: PLC2701
     attrs_repr,
     dim_summary_limited,
     inline_variable_array_repr,
@@ -67,6 +70,65 @@ def sc_repr(sc) -> str:
         ]
     )
 
-    summary.append(attrs_repr(sc.attrs, max_rows=max_rows))
+    summary.append(attrs_repr(sc.attrs, col_width=col_width, max_rows=max_rows))
 
+    return "\n".join(summary)
+
+
+def summarize_criteria(
+    name,
+    criteria,
+    col_width: int,
+    max_width: int | None = None,
+):
+    """Summarize a criteria in one line, e.g., for the LandSuitabilityAnalysis.__repr__."""
+    if max_width is None:
+        max_width_options = OPTIONS["display_width"]
+        if not isinstance(max_width_options, int):
+            raise TypeError(f"`max_width` value of `{max_width}` is not a valid int")
+        else:
+            max_width = max_width_options
+
+    first_col = pretty_print(f"    {criteria.name} ", col_width)
+    wgt = f"(w={criteria.weight}) "
+
+    front_str = f"{first_col}{wgt}"
+
+    if criteria.category:
+        cat = f"{criteria.category} "
+    else:
+        cat = ""
+
+    if criteria.func:
+        func = f"{sf_short_repr(criteria.func)} "
+    else:
+        func = ""
+
+    details_width = max_width - len(front_str)
+    details_str = maybe_truncate(f"{cat}{func}", details_width)
+
+    return front_str + details_str
+
+
+criteria_repr = functools.partial(
+    _mapping_repr,
+    title="Criteria",
+    summarizer=summarize_criteria,
+    expand_option_name="display_expand_data_vars",
+)
+
+
+def lsa_repr(lsa):
+    """Return a string representation of a LandSuitabilityAnalysis."""
+    max_rows = OPTIONS["display_max_rows"]
+
+    col_width = _calculate_col_width(
+        [sc.name for sc in lsa.criteria.values()] + [k for k in lsa.attrs.keys()],
+    )
+
+    summary = [f"<LandSuitabilityAnalysis> {lsa.land_use!r}"]
+
+    summary.append(criteria_repr(lsa.criteria, col_width=col_width, max_rows=max_rows))
+
+    summary.append(attrs_repr(lsa.attrs, col_width=col_width, max_rows=max_rows))
     return "\n".join(summary)

--- a/src/lsapy/core/formatting.py
+++ b/src/lsapy/core/formatting.py
@@ -50,34 +50,23 @@ def sc_repr(sc) -> str:
     max_rows = OPTIONS["display_max_rows"]
     max_width = OPTIONS["display_width"]
 
-    exclude_attrs = ["name", "weight", "category", "from_indicator", "is_computed"]
-    attrs = {k: v for k, v in sc.attrs.items() if k not in exclude_attrs}
-
-    col_width = _calculate_col_width([f"{k}:" for k in attrs.keys()] + ["Dimensions"])
-    name_col = pretty_print("    Name", col_width)
+    col_width = _calculate_col_width([f"{k}:" for k in sc.attrs.keys()] + ["Dimensions"])
 
     summary = [f"<SuitabilityCriteria> {sc.name!r}{sc_params_repr(sc)}"]
 
     if sc.func:
-        summary.extend(
-            [
-                "Function:",
-                f"    {maybe_truncate(sf_short_repr(sc.func), max_width)}",
-                # f"{name_col}{sc.func.func.__name__} "
-                # f"{pretty_print("    Parameters", col_width)}{sc.func.params!r} "
-            ]
-        )
+        summary.extend(["Function:", f"    {maybe_truncate(sf_repr(sc.func), max_width)}"])
 
     dims = pretty_print("    Dimensions", col_width)
     summary.extend(
         [
             "Indicator:",
-            f"{name_col}{sc.indicator.name} ",
+            f"{pretty_print('    Name', col_width)}{sc.indicator.name} ",
             data_repr(sc.indicator, col_width, max_width),
             f"{dims}{dim_summary_limited(sc.indicator.sizes, len(dims) + 1, max_rows)} ",
         ]
     )
 
-    summary.append(attrs_repr(attrs, max_rows=max_rows))
+    summary.append(attrs_repr(sc.attrs, max_rows=max_rows))
 
     return "\n".join(summary)

--- a/src/lsapy/core/options.py
+++ b/src/lsapy/core/options.py
@@ -1,0 +1,12 @@
+"""LSAPy Options."""
+
+from __future__ import annotations
+
+OPTIONS = {
+    "display_width": 80,
+    "display_max_rows": 12,
+}
+
+# class set_options:
+#     # TODO: Implement context manager for setting options
+#     ...

--- a/src/lsapy/criteria.py
+++ b/src/lsapy/criteria.py
@@ -158,19 +158,16 @@ class SuitabilityCriteria:
             raise ValueError("The suitability function is not defined. Please provide a valid function.")
         else:
             sc: xr.DataArray = xr.apply_ufunc(self.func, self.indicator)
-        return sc.rename(self.name).assign_attrs(
-            dict(
-                {
-                    k: v
-                    for k, v in self.attrs.items()
-                    if k not in ["name", "func_method", "from_indicator", "is_computed"]
-                },
-                **{
-                    "history": f"func_method: {self.func if self.func is not None else 'unknown'}; "
-                    f"from_indicator: [{self._from_indicator}]"
-                },
-            )
+
+        attrs = {"weight": self.weight}
+        if self.category:
+            attrs["category"] = self.category
+        attrs.update(self._attrs)
+        attrs["history"] = (
+            f"func_method: {self.func if self.func is not None else 'unknown'}; "
+            f"from_indicator: [{self._from_indicator}]"
         )
+        return sc.rename(self.name).assign_attrs(attrs)
 
 
 def _get_indicator_description(indicator: xr.Dataset | xr.DataArray) -> str:

--- a/src/lsapy/criteria.py
+++ b/src/lsapy/criteria.py
@@ -116,6 +116,30 @@ class SuitabilityCriteria:
         """Return a string representation of the suitability criteria."""
         return fmt.sc_repr(self)
 
+    @property
+    def attrs(self) -> dict[Any, Any]:
+        """
+        Dictionary of the suitability criteria attributes.
+
+        Returns
+        -------
+        dict
+            Dictionary containing the suitability criteria attributes.
+        """
+        return self._attrs
+
+    @attrs.setter
+    def attrs(self, value: Mapping[Any, Any]) -> None:
+        """
+        Set the attributes of the suitability criteria.
+
+        Parameters
+        ----------
+        value : Mapping[Any, Any]
+            Mapping of attributes to set for the suitability criteria.
+        """
+        self._attrs = dict(value)
+
     def compute(self) -> xr.DataArray:
         """
         Compute the suitability of the criteria.
@@ -147,30 +171,6 @@ class SuitabilityCriteria:
                 },
             )
         )
-
-    @property
-    def attrs(self) -> dict[Any, Any]:
-        """
-        Dictionary of the suitability criteria attributes.
-
-        Returns
-        -------
-        dict
-            Dictionary containing the suitability criteria attributes.
-        """
-        return self._attrs
-
-    @attrs.setter
-    def attrs(self, value: Mapping[Any, Any]) -> None:
-        """
-        Set the attributes of the suitability criteria.
-
-        Parameters
-        ----------
-        value : Mapping[Any, Any]
-            Mapping of attributes to set for the suitability criteria.
-        """
-        self._attrs = dict(value)
 
 
 def _get_indicator_description(indicator: xr.Dataset | xr.DataArray) -> str:

--- a/src/lsapy/criteria.py
+++ b/src/lsapy/criteria.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import xarray as xr
 
+import lsapy.core.formatting as fmt
 from lsapy.functions import SuitabilityFunction
 
 __all__ = ["SuitabilityCriteria"]
@@ -33,11 +35,15 @@ class SuitabilityCriteria:
     category : str | None, optional
         Category of the criteria. The default is None.
     long_name : str | None, optional
-        A long name for the criteria. The default is None.
+        A long name for the criteria. The default is None. If provided, it will be stored as an attribute.
     description : str | None, optional
-        A description for the criteria. The default is None.
+        A description for the criteria. The default is None. If provided, it will be stored as an attribute.
     comment : str | None, optional
-        Additional information about the criteria.
+        Additional information about the criteria. The default is None.
+        If provided, it will be stored as an attribute.
+    attrs : Mapping[Any, Any] | None, optional
+        Arbitrary metadata to store with the criteria, in addition to the attributes
+        `long_name`, `description`, and `comment`. The default is None.
     is_computed : bool, optional
         If the indicator data already contains the computed suitability values. Default is False.
 
@@ -84,6 +90,7 @@ class SuitabilityCriteria:
         long_name: str | None = None,
         description: str | None = None,
         comment: str | None = None,
+        attrs: Mapping[Any, Any] | None = None,
         is_computed: bool = False,
     ) -> None:
         self.name = name
@@ -91,30 +98,23 @@ class SuitabilityCriteria:
         self.func = func
         self.weight = weight
         self.category = category
-        self.long_name = long_name
-        self.description = description
-        self.comment = comment
+
+        self._attrs = {}
+        if long_name:
+            self._attrs["long_name"] = long_name
+        if description:
+            self._attrs["description"] = description
+        if comment:
+            self._attrs["comment"] = comment
+        if attrs and isinstance(attrs, Mapping):
+            self._attrs.update(attrs)
+
         self.is_computed = is_computed
         self._from_indicator = _get_indicator_description(indicator)
 
     def __repr__(self) -> str:
-        """Return a string representation for a particular criteria."""
-        attrs = []
-        attrs.append(f"name='{self.name}'")
-        attrs.append(f"indicator={self.indicator.name}")
-        attrs.append(f"func={self.func if self.func is not None else 'unknown'}")
-        attrs.append(f"weight={self.weight}")
-        if self.category is not None:
-            attrs.append(f"category='{self.category}'")
-        if self.long_name is not None:
-            attrs.append(f"long_name='{self.long_name}'")
-        if self.description is not None:
-            attrs.append(f"description='{self.description}'")
-        if self.comment is not None:
-            attrs.append(f"comment='{self.comment}'")
-        if self.is_computed:
-            attrs.append("is_computed=True")
-        return f"{self.__class__.__name__}({', '.join(attrs) if attrs else ''})"
+        """Return a string representation of the suitability criteria."""
+        return fmt.sc_repr(self)
 
     def compute(self) -> xr.DataArray:
         """
@@ -149,29 +149,28 @@ class SuitabilityCriteria:
         )
 
     @property
-    def attrs(self) -> dict:
+    def attrs(self) -> dict[Any, Any]:
         """
-        Dictionary of the criteria attributes.
+        Dictionary of the suitability criteria attributes.
 
         Returns
         -------
         dict
-            Dictionary with the criteria attributes.
+            Dictionary containing the suitability criteria attributes.
         """
-        return {
-            k: v
-            for k, v in {
-                "name": self.name,
-                "weight": self.weight,
-                "category": self.category,
-                "long_name": self.long_name,
-                "description": self.description,
-                "func_method": self.func if self.func is not None else "unknown",
-                "from_indicator": self._from_indicator,
-                "is_computed": self.is_computed,
-            }.items()
-            if v is not None
-        }
+        return self._attrs
+
+    @attrs.setter
+    def attrs(self, value: Mapping[Any, Any]) -> None:
+        """
+        Set the attributes of the suitability criteria.
+
+        Parameters
+        ----------
+        value : Mapping[Any, Any]
+            Mapping of attributes to set for the suitability criteria.
+        """
+        self._attrs = dict(value)
 
 
 def _get_indicator_description(indicator: xr.Dataset | xr.DataArray) -> str:

--- a/src/lsapy/functions/_suitability.py
+++ b/src/lsapy/functions/_suitability.py
@@ -9,6 +9,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import numpy as np
 
+import lsapy.core.formatting as fmt
 from lsapy.core.functions import get_function_from_name
 
 __all__ = [
@@ -89,8 +90,7 @@ class SuitabilityFunction:
         return np.vectorize(func, otypes=[np.float32])(x)
 
     def __repr__(self):
-        """Return the string representation of the object."""
-        return f"{self.__class__.__name__}(func={self.func.__name__}, params={self.params})"
+        return fmt.sf_repr(self)
 
     @property
     def attrs(self) -> dict[str, Any]:

--- a/src/lsapy/lsa.py
+++ b/src/lsapy/lsa.py
@@ -336,7 +336,9 @@ class LandSuitabilityAnalysis:
 
         # Reassign attributes to each criteria
         for sc in out.data_vars:
-            out[sc].attrs = {k: v for k, v in self.criteria[sc].attrs.items() if k != "is_computed"}
+            out[sc].attrs = self.criteria[sc].attrs
+        out.attrs["land_use"] = self.land_use
+        out.attrs["criteria"] = self._criteria_list
         out.attrs.update(self.attrs)
         return out
 

--- a/src/lsapy/lsa.py
+++ b/src/lsapy/lsa.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
 import xarray as xr
 
+from lsapy.core.formatting import lsa_repr
 from lsapy.criteria import SuitabilityCriteria
 
 __all__ = ["LandSuitabilityAnalysis"]
@@ -27,13 +29,20 @@ class LandSuitabilityAnalysis:
     criteria : dict[str, SuitabilityCriteria]
         A dictionary of suitability criteria where the key is the name of the criteria.
     short_name : str | None, optional
-        A short name for the land suitability analysis. The default is None.
+        A short name for the land suitability analysis. The default is None. If provided,
+        it will be stored as an attribute.
     long_name : str | None, optional
-        A long name for the land suitability analysis. The default is None.
+        A long name for the land suitability analysis. The default is None. If provided,
+        it will be stored as an attribute.
     description : str | None, optional
-        A description for the land suitability analysis. The default is None.
+        A description for the land suitability analysis. The default is None. If provided,
+        it will be stored as an attribute.
     comment : str | None, optional
-        Additional information about the land suitability analysis.
+        Additional information about the land suitability analysis. The default is None.
+        If provided, it will be stored as an attribute.
+    attrs : Mapping[Any, Any] | None, optional
+        Arbitrary metadata to store with the land suitability analysis, in addition to the attributes
+        `short_name`, `long_name`, `description`, and `comment`. The default is None.
 
     Examples
     --------
@@ -88,13 +97,22 @@ class LandSuitabilityAnalysis:
         long_name: str | None = None,
         description: str | None = None,
         comment: str | None = None,
+        attrs: Mapping[Any, Any] | None = None,
     ) -> None:
         self.land_use = land_use
         self.criteria = criteria
-        self.short_name = short_name
-        self.long_name = long_name
-        self.description = description
-        self.comment = comment
+
+        self._attrs = {}
+        if short_name:
+            self._attrs["short_name"] = short_name
+        if long_name:
+            self._attrs["long_name"] = long_name
+        if description:
+            self._attrs["description"] = description
+        if comment:
+            self._attrs["comment"] = comment
+        if attrs and isinstance(attrs, Mapping):
+            self._attrs.update(attrs)
 
         self._sort_criteria_by_weight()  # important if suitability as limited factor
         self._criteria_list = [sc.name for sc in self.criteria.values()]
@@ -103,37 +121,31 @@ class LandSuitabilityAnalysis:
 
     def __repr__(self) -> str:
         """Return a string representation of the land suitability."""
-        attrs = []
-        for k, v in self.attrs.items():
-            if isinstance(v, str):
-                v_ = f"'{v}'"
-            else:
-                v_ = v
-            attrs.append(f"{k}={v_}")
-        return f"{self.__class__.__name__}({', '.join(attrs) if attrs else ''})"
+        return lsa_repr(self)
 
     @property
-    def attrs(self):
+    def attrs(self) -> dict[Any, Any]:
         """
-        Dictionary of attributes of the land suitability analysis.
+        Dictionary of the Land Suitability Analysis attributes.
 
         Returns
         -------
         dict
-            A dictionary of attributes of the land suitability analysis, including name, criteria, short_name,
-            long_name, and description.
+            Dictionary containing the attributes of the Land Suitability Analysis.
         """
-        return {
-            k: v
-            for k, v in {
-                "land_use": self.land_use,
-                "criteria": self._criteria_list,
-                "short_name": self.short_name,
-                "long_name": self.long_name,
-                "description": self.description,
-            }.items()
-            if v is not None
-        }
+        return self._attrs
+
+    @attrs.setter
+    def attrs(self, value: Mapping[Any, Any]) -> None:
+        """
+        Set the attributes of the Land Suitability Analysis.
+
+        Parameters
+        ----------
+        value : Mapping[Any, Any]
+            Mapping of attributes to set for the Land Suitability Analysis.
+        """
+        self._attrs = dict(value)
 
     def run(
         self,

--- a/tests/test_criteria.py
+++ b/tests/test_criteria.py
@@ -14,45 +14,67 @@ from lsapy.criteria import _get_indicator_description  # noqa: PLC2701
 class TestSuitabilityCriteria:
     def test_repr(self, criteria_anpr, criteria_drain):
         # test for annual precipitation criteria
-        criteria_anpr.long_name = "Annual Precipitation"
-        criteria_anpr.description = "This is the annual precipitation criteria."
-        anpr_repr = repr(criteria_anpr)
-
-        assert "SuitabilityCriteria(" in anpr_repr
-        assert "name='annual_precipitation'" in anpr_repr
-        assert "indicator=prcptot" in anpr_repr
-        assert f"func={repr(criteria_anpr.func)}" in anpr_repr
-        assert "weight=1" in anpr_repr
-        assert "category='climate'" in anpr_repr
-        assert "long_name='Annual Precipitation'" in anpr_repr
-        assert "description='This is the annual precipitation criteria.'" in anpr_repr
+        criteria_anpr.attrs.update(
+            {
+                "long_name": "Annual Precipitation",
+                "description": "This is the annual precipitation criteria.",
+                "comment": "Some comment about annual precipitation.",
+            }
+        )
+        expected_repr = (
+            "<SuitabilityCriteria> 'annual_precipitation'(weight: 1, category: climate)\n"
+            "Function:\n"
+            "    SuitabilityFunction(func=vetharaniam2022_eq5, params={'a': -0.71, 'b': 1100})\n"
+            "Indicator:\n"
+            "    Name          prcptot \n"
+            "    Data          int32 500B 1000 1000 1000 1000 1000 ... 1000 1000 1000 1000\n"
+            "    Dimensions    lat: 5, lon: 5, time: 5 \n"
+            "Attributes:\n    long_name:     Annual Precipitation\n"
+            "    description:   This is the annual precipitation criteria.\n"
+            "    comment:       Some comment about annual precipitation."
+        )
+        assert repr(criteria_anpr) == expected_repr
 
         # test for drainage criteria
-        criteria_drain.comment = "Some comment about drainage."
-        criteria_drain.is_computed = True
-        drain_repr = repr(criteria_drain)
+        expected_repr = (
+            "<SuitabilityCriteria> 'drainage_class'(weight: 2, category: soilTerrain)\n"
+            "Function:\n"
+            "    SuitabilityFunction(func=discrete, params={'rules': {1: 0, 2: 0.1, 3: 0.5, 4:...\n"
+            "Indicator:\n"
+            "    Name        drainage \n"
+            "    Data        float64 200B 3.0 3.0 3.0 3.0 3.0 3.0 ... 3.0 3.0 3.0 3.0 3.0 3.0\n"
+            "    Dimensions  lat: 5, lon: 5 \n"
+            "Attributes:\n"
+            "    *empty*"
+        )
+        assert repr(criteria_drain) == expected_repr
 
-        assert "SuitabilityCriteria(" in drain_repr
-        assert "name='drainage_class'" in drain_repr
-        assert "indicator=drainage" in drain_repr
-        assert f"func={repr(criteria_drain.func)}" in drain_repr
-        assert "weight=2" in drain_repr
-        assert "category='soilTerrain'" in drain_repr
-        assert "comment='Some comment about drainage.'" in drain_repr
-        assert "is_computed=True" in drain_repr
+    def test_attrs(self, criteria_anpr, annual_precip, sf_anpr):
+        assert criteria_anpr.attrs == {}
+        criteria_anpr.attrs = {
+            "long_name": "Annual Precipitation",
+            "description": "This is the annual precipitation criteria.",
+            "comment": "Some comment about annual precipitation.",
+        }
+        assert criteria_anpr.attrs["long_name"] == "Annual Precipitation"
+        assert criteria_anpr.attrs["description"] == "This is the annual precipitation criteria."
+        assert criteria_anpr.attrs["comment"] == "Some comment about annual precipitation."
 
-    def test_attrs(self, criteria_anpr, sf_anpr):
-        sc = criteria_anpr.compute()
-
-        assert sc.name == "annual_precipitation"
-        assert sc.attrs["weight"] == 1
-        assert sc.attrs["category"] == "climate"
-        assert f"func_method: {repr(sf_anpr)}" in sc.attrs["history"]
-        assert "from_indicator:" in sc.attrs["history"]
-        assert "name: prcptot" in sc.attrs["history"]
-        assert "units: mm" in sc.attrs["history"]
-        assert "standard_name: lwe_thickness_of_precipitation_amount" in sc.attrs["history"]
-        assert "long_name: Total accumulated precipitation" in sc.attrs["history"]
+        # test when provided when creating the criteria
+        sc = SuitabilityCriteria(
+            name="annual_precipitation",
+            category="climate",
+            indicator=annual_precip,
+            func=sf_anpr,
+            long_name="Annual Precipitation",
+            description="This is the annual precipitation criteria.",
+            comment="Some comment about annual precipitation.",
+            attrs={"another_attr": "value"},
+        )
+        assert sc.attrs["long_name"] == "Annual Precipitation"
+        assert sc.attrs["description"] == "This is the annual precipitation criteria."
+        assert sc.attrs["comment"] == "Some comment about annual precipitation."
+        assert sc.attrs["another_attr"] == "value"
 
     def test_format(self, criteria_anpr):
         sc = criteria_anpr.compute()
@@ -64,6 +86,11 @@ class TestSuitabilityCriteria:
         np.testing.assert_equal(sc.lat.values, np.arange(5))
         np.testing.assert_equal(sc.lon.values, np.arange(5))
         np.testing.assert_equal(sc.time.values, pd.date_range("2000-01-01", periods=5, freq="YS"))
+
+        # test output attrs
+        for k in criteria_anpr.attrs:
+            assert k in sc.attrs
+            assert sc.attrs[k] == criteria_anpr.attrs[k]
 
     def test_compute_func(self, criteria_anpr, criteria_drain):
         # test suitability function computation

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,37 @@
+"""Tests for repr formatting functions."""
+
+from __future__ import annotations
+
+from lsapy import SuitabilityCriteria
+from lsapy.core.formatting import summarize_criteria
+
+
+class TestSummarizeCriteria:
+    def test_output(self, criteria_gdd, growing_degree_days):
+        res = summarize_criteria("criteria", criteria_gdd, 20, 80)
+        expected_res = "    growing_degre...(w=3) climate vetharaniam2022_eq5(a=-0.55, b=1350) "
+        assert res == expected_res
+        # test without category and function
+        sc = SuitabilityCriteria(
+            name="test_criteria",
+            indicator=growing_degree_days,
+        )
+        res = summarize_criteria("criteria", sc, 20, 80)
+        expected_res = "    test_criteria   (w=1) "
+        assert res == expected_res
+
+    def test_col_width(self, criteria_gdd):
+        # col_width=0
+        res = summarize_criteria("criteria", criteria_gdd, col_width=0, max_width=80)
+        expected_res = "    growing_degree_da...(w=3) climate vetharaniam2022_eq5(a=-0.55, b=1350) "
+        assert res == expected_res
+        # col_width=max_width
+        res = summarize_criteria("criteria", criteria_gdd, col_width=50, max_width=80)
+        expected_res = "    growing_degree_days                           (w=3) climate vetharaniam20..."
+        assert res == expected_res
+
+    def test_max_width(self, criteria_gdd):
+        # default max_width
+        res = summarize_criteria("criteria", criteria_gdd, col_width=20)
+        expected_res = "    growing_degre...(w=3) climate vetharaniam2022_eq5(a=-0.55, b=1350) "
+        assert res == expected_res

--- a/tests/test_lsa.py
+++ b/tests/test_lsa.py
@@ -20,6 +20,7 @@ def lsa(criteria) -> LandSuitabilityAnalysis:
         description="This is a test land use.",
         comment="An optional comment.",
         criteria=criteria,
+        attrs={"another_attr": "value"},
     )
 
 
@@ -51,26 +52,36 @@ class TestLandSuitabilityAnalysis:
         assert lsa.weights_by_category == {"climate": 4, "soilTerrain": 4}
 
     def test_attrs(self, lsa):
-        assert lsa.land_use == "land_use"
-        assert lsa.short_name == "test_land_use"
-        assert lsa.long_name == "Test Land Use"
-        assert lsa.description == "This is a test land use."
-        assert lsa.comment == "An optional comment."
-        assert lsa.category == ["climate", "soilTerrain"]
-        assert lsa._criteria_list == [
-            "growing_degree_days",
-            "potential_rooting_depth",
-            "drainage_class",
-            "annual_precipitation",
-        ]
+        # test when provided when creating the lsa
+        assert lsa.attrs["long_name"] == "Test Land Use"
+        assert lsa.attrs["description"] == "This is a test land use."
+        assert lsa.attrs["comment"] == "An optional comment."
+        assert lsa.attrs["another_attr"] == "value"
+        lsa = LandSuitabilityAnalysis(land_use="land_use", criteria=lsa.criteria)
+        assert lsa.attrs == {}
+        lsa.attrs = {
+            "long_name": "Test Land Use",
+            "description": "This is a test land use.",
+            "comment": "An optional comment.",
+        }
+        assert lsa.attrs["long_name"] == "Test Land Use"
+        assert lsa.attrs["description"] == "This is a test land use."
+        assert lsa.attrs["comment"] == "An optional comment."
 
     def test_repr(self, lsa):
         expected_repr = (
-            "LandSuitabilityAnalysis(land_use='land_use', "
-            "criteria=['growing_degree_days', 'potential_rooting_depth', "
-            "'drainage_class', 'annual_precipitation'], "
-            "short_name='test_land_use', long_name='Test Land Use', "
-            "description='This is a test land use.')"
+            "<LandSuitabilityAnalysis> 'land_use'\n"
+            "Criteria:\n"
+            "    growing_degree_days      (w=3) climate vetharaniam2022_eq5(a=-0.55, b=1350) \n"
+            "    potential_rooting_depth  (w=2) soilTerrain vetharaniam2022_eq5(a=-9.8, b=...\n"
+            "    drainage_class           (w=2) soilTerrain discrete(rules={1: 0, 2: 0.1, ...\n"
+            "    annual_precipitation     (w=1) climate vetharaniam2022_eq5(a=-0.71, b=1100) \n"
+            "Attributes:\n"
+            "    short_name:               test_land_use\n"
+            "    long_name:                Test Land Use\n"
+            "    description:              This is a test land use.\n"
+            "    comment:                  An optional comment.\n"
+            "    another_attr:             value"
         )
         assert repr(lsa) == expected_repr
 
@@ -101,9 +112,9 @@ class TestLandSuitabilityAnalysis:
         assert all([c in res.data_vars for c in lsa._criteria_list])
         assert res.attrs["criteria"] == lsa._criteria_list
         assert res.attrs["land_use"] == lsa.land_use
-        assert res.attrs["short_name"] == lsa.short_name
-        assert res.attrs["long_name"] == lsa.long_name
-        assert res.attrs["description"] == lsa.description
+        assert res.attrs["short_name"] == "test_land_use"
+        assert res.attrs["long_name"] == "Test Land Use"
+        assert res.attrs["description"] == "This is a test land use."
         # test values
         np.testing.assert_array_almost_equal(res.growing_degree_days.values, 0.75, decimal=2)
         np.testing.assert_array_almost_equal(res.potential_rooting_depth.values, 0.95, decimal=2)
@@ -140,9 +151,9 @@ class TestLandSuitabilityAnalysis:
         assert all([c in res.data_vars for c in lsa.category])
         assert res.attrs["land_use"] == lsa.land_use
         assert res.attrs["criteria"] == lsa._criteria_list
-        assert res.attrs["short_name"] == lsa.short_name
-        assert res.attrs["long_name"] == lsa.long_name
-        assert res.attrs["description"] == lsa.description
+        assert res.attrs["short_name"] == "test_land_use"
+        assert res.attrs["long_name"] == "Test Land Use"
+        assert res.attrs["description"] == "This is a test land use."
         # test values
         np.testing.assert_array_almost_equal(res.climate.values, 0.57, decimal=2)
         np.testing.assert_array_almost_equal(res.soilTerrain.values, 0.69, decimal=2)
@@ -162,9 +173,9 @@ class TestLandSuitabilityAnalysis:
         assert "suitability" in res.data_vars
         assert res.attrs["land_use"] == lsa.land_use
         assert res.attrs["criteria"] == lsa._criteria_list
-        assert res.attrs["short_name"] == lsa.short_name
-        assert res.attrs["long_name"] == lsa.long_name
-        assert res.attrs["description"] == lsa.description
+        assert res.attrs["short_name"] == "test_land_use"
+        assert res.attrs["long_name"] == "Test Land Use"
+        assert res.attrs["description"] == "This is a test land use."
         # test values
         np.testing.assert_array_almost_equal(res.suitability.values, 0.63, decimal=2)
         # test with by_category=False, should return aggregation of criteria


### PR DESCRIPTION
<!--This template come from [xclim](https://github.com/Ouranosinc/xclim) project.-->
<!--Please ensure the PR fulfills the following requirements! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #55 
- [x] Tests for the changes have been added (for bug fixes / features)
  - [x] (If applicable) Documentation has been added / updated (for bug fixes / features)
- [ ] CHANGELOG.rst has been updated (with summary of main changes)
  - [ ] Link to issue (issue #N) and pull request (PR #N) has been added

### What kind of change does this PR introduce?
* ``repr`` methods of ``SuitabilityFunction``, ``SuitabilityCriteria`` and ``LandSuitabilityAnalysis`` have been modified to provide more user-friendly information.
* The ``lsapy.core.formatting`` module has been added and contains ``repr`` formatting functions.
* A setter has been added to ``attrs`` method of ``SuitabilityCriteria`` and ``LandSuitabilityAnalysis``.

### Does this PR introduce a breaking change?
* ``short_name``, ``long_name``, ``description`` and ``comment`` attributes of ``SuitabilityCriteria`` and ``LandSuitabilityAnalysis`` have been removed and are now store in the ``attrs`` attribute.
