### PR TITLE
Force Python 3.13 max in CI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r ci/requirements_ci.txt

--- a/.github/workflows/tag-testpypi.yml
+++ b/.github/workflows/tag-testpypi.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -23,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r ci/requirements_ci.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,13 +14,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.13']
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python-version }}
       - name: Install CI libraries
         run: |
           python -m pip install --require-hashes -r ci/requirements_ci.txt


### PR DESCRIPTION
### What kind of change does this PR introduce?

* Force to use Python 3.13 max in CI

### Does this PR introduce a breaking change?
No.

### Other information:
Some CI dependencies still need to adapt to the newly released Python 3.14 preventing the workflow to run properly.