### PR TITLE
Add h5netcdf as a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 dynamic = ["description", "version"]
 dependencies = [
   "geopandas >=0.14.0",
+  "h5netcdf >=1.4.0",
   "numpy >=1.26.0",
   "pandas >=2.2.0",
   "pooch >=1.8.2",


### PR DESCRIPTION
## Summary

- Add `h5netcdf >= 1.4.0` to the required dependencies in `pyproject.toml`

## Motivation

`open_data` reads NetCDF4 files via `xarray.open_mfdataset`, which requires an HDF5 backend at runtime. Without `h5netcdf`, a clean `pip install lsapy` results in an `ImportError: No module named 'h5py'` when calling `open_data("land", ...)`, because xarray attempts to use `h5netcdf` as a backend and that package depends on `h5py`.

This was identified during the pyOpenSci peer review: https://github.com/pyOpenSci/software-submission/issues/261